### PR TITLE
[feat] Adds option to load demo xAPI data

### DIFF
--- a/tutorclickhouse/plugin.py
+++ b/tutorclickhouse/plugin.py
@@ -34,6 +34,11 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
     <listen_host>0.0.0.0</listen_host>
     <listen_try>1</listen_try>
         """),
+
+        # Demo data (optional)
+        ("CLICKHOUSE_LOAD_DEMO_DATA", "no"), # set to "xapi" to load xapi demo data into clickhouse
+        ("CLICKHOUSE_LOAD_DEMO_XAPI_BATCHES", "100"),
+        ("CLICKHOUSE_LOAD_DEMO_XAPI_BATCH_SIZE", "100"),
     ]
 )
 
@@ -72,6 +77,10 @@ hooks.Filters.CONFIG_OVERRIDES.add_items(
 hooks.Filters.COMMANDS_INIT.add_item((
     "clickhouse_service",
     ("clickhouse", "tasks", "init.sh"),
+))
+hooks.Filters.COMMANDS_INIT.add_item((
+    "clickhouse_service",
+    ("clickhouse", "tasks", "demo-xapi.sh"),
 ))
 
 

--- a/tutorclickhouse/plugin.py
+++ b/tutorclickhouse/plugin.py
@@ -19,6 +19,7 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         ("CLICKHOUSE_VERSION", __version__),
         ("CLICKHOUSE_HOST", "clickhouse_service"),
         ("CLICKHOUSE_PORT", "9000"),
+        ("CLICKHOUSE_HTTP_PORT", "8123"),
         ("CLICKHOUSE_XAPI_DATABASE", "xapi"),
 
         # This can be used to override some configuration values in
@@ -133,8 +134,8 @@ clickhouse_service:
         CLICKHOUSE_PASSWORD: "{{ CLICKHOUSE_ADMIN_PASSWORD }}"
         CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1
     ports:
-        - 18123:8123
-        - 19000:9000
+        - 18123:{{ CLICKHOUSE_HTTP_PORT }}
+        - 19000:{{ CLICKHOUSE_PORT }}
     ulimits:
         nofile:
             soft: 262144

--- a/tutorclickhouse/templates/clickhouse/tasks/demo-xapi.sh
+++ b/tutorclickhouse/templates/clickhouse/tasks/demo-xapi.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+case "{{ CLICKHOUSE_LOAD_DEMO_DATA }}" in
+
+    *"xapi"*)
+        echo "Installing python/pip..."
+        apt update
+        apt install -y python3-pip python3.8-venv git
+        python3 -m venv virtualenv
+        . virtualenv/bin/activate
+
+        echo "Loading demo xAPI data..."
+        pip install git+https://github.com/openedx/xapi-db-load@0.1#egg=xapi-db-load==0.1
+        xapi-db-load --backend clickhouse \
+            --num_batches "{{ CLICKHOUSE_LOAD_DEMO_XAPI_BATCHES }}" \
+            --batch_size "{{ CLICKHOUSE_LOAD_DEMO_XAPI_BATCH_SIZE }}" \
+            --db_host "{{ CLICKHOUSE_HOST }}" \
+            --db_port "{{ CLICKHOUSE_HTTP_PORT }}" \
+            --db_username "{{ CLICKHOUSE_ADMIN_USER }}" \
+            --db_password "{{ CLICKHOUSE_ADMIN_PASSWORD }}" \
+            --db_name "{{ CLICKHOUSE_XAPI_DATABASE }}"
+        echo "Done."
+        ;;
+esac


### PR DESCRIPTION
Ensures the ports exposed by Clickhouse (for client and HTTP) are configurable, and accessible as variables in Tutor plugins.
Adds option to load xapi demo data into Clickhouse on init.

**Dependencies**

These need to be merged first, and a `0.1` tag added to `xapi-db-api`.

* https://github.com/bmtcril/xapi-db-load/pull/1
* https://github.com/openedx/xapi-db-load/pull/5

**Related discussions**

* Part of implementing https://github.com/openedx/openedx-oars/issues/30

**Testing instructions**

1. Install this branch to your tutor virtualenv.
2. Run `tutor config save` and `tutor local restart clickhouse` to ensure these config changes are valid.
3. To ensure the demo data is disabled by default: Run `tutor local do init --limit clickhouse`, and note that no demo tables are created on the `xapi` database.
4. To test the demo data: Run `tutor config save -s CLICKHOUSE_LOAD_DEMO_DATA=xapi && tutor local do init --limit clickhouse`, and note that a `xapi_events_all` table is added to the `xapi` database.

