### PR TITLE
Move user / schema creation to OARS

### DIFF
--- a/tutorclickhouse/plugin.py
+++ b/tutorclickhouse/plugin.py
@@ -17,7 +17,7 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         # Each new setting is a pair: (setting_name, default_value).
         # Prefix your setting names with 'CLICKHOUSE_'.
         ("CLICKHOUSE_VERSION", __version__),
-        ("CLICKHOUSE_HOST", "clickhouse_service"),
+        ("CLICKHOUSE_HOST", "clickhouse"),
         ("CLICKHOUSE_PORT", "9000"),
         ("CLICKHOUSE_HTTP_PORT", "8123"),
         ("CLICKHOUSE_XAPI_DATABASE", "xapi"),
@@ -43,8 +43,6 @@ hooks.Filters.CONFIG_UNIQUE.add_items(
         # For instance: passwords, secret keys, etc.
         # Each new setting is a pair: (setting_name, unique_generated_value).
         # Prefix your setting names with 'CLICKHOUSE_'.
-        # For example:
-        # ("CLICKHOUSE_SECRET_KEY", "{{ 24|random_string }}"),
         ("CLICKHOUSE_ADMIN_USER", "ch_admin"),
         ("CLICKHOUSE_ADMIN_PASSWORD", "{{ 24|random_string }}"),
         ("CLICKHOUSE_LRS_USER", "ch_lrs"),
@@ -70,7 +68,7 @@ hooks.Filters.CONFIG_OVERRIDES.add_items(
 
 # To run the script from templates/clickhouse/tasks/myservice/init.sh, add:
 hooks.Filters.COMMANDS_INIT.add_item((
-    "clickhouse_service",
+    "clickhouse",
     ("clickhouse", "tasks", "init.sh"),
 ))
 
@@ -80,8 +78,8 @@ hooks.Filters.COMMANDS_INIT.add_item((
 ########################################
 
 # hooks.Filters.IMAGES_BUILD.add_item((
-#     "clickhouse_service",
-#     ("plugins", "clickhouse", "build", "clickhouse_service"),
+#     "clickhouse",
+#     ("plugins", "clickhouse", "build", "clickhouse"),
 #     "tutor_clickhouse:{{ CLICKHOUSE_VERSION }}",
 #     (),
 # ))
@@ -126,7 +124,7 @@ hooks.Filters.ENV_PATCHES.add_item(
     (
         "local-docker-compose-services",
         """
-clickhouse_service:
+clickhouse:
     image: clickhouse/clickhouse-server:latest
     environment:
         CLICKHOUSE_DB: xapi
@@ -134,8 +132,8 @@ clickhouse_service:
         CLICKHOUSE_PASSWORD: "{{ CLICKHOUSE_ADMIN_PASSWORD }}"
         CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1
     ports:
-        - 18123:{{ CLICKHOUSE_HTTP_PORT }}
-        - 19000:{{ CLICKHOUSE_PORT }}
+        - 8123:{{ CLICKHOUSE_HTTP_PORT }}
+        - 9000:{{ CLICKHOUSE_PORT }}
     ulimits:
         nofile:
             soft: 262144
@@ -151,10 +149,10 @@ hooks.Filters.ENV_PATCHES.add_item(
     (
         "local-docker-compose-jobs-services",
         """
-clickhouse_service-job:
+clickhouse-job:
     image: clickhouse/clickhouse-server:latest
     depends_on: 
-        - clickhouse_service
+        - clickhouse
         """,
     )
 )

--- a/tutorclickhouse/plugin.py
+++ b/tutorclickhouse/plugin.py
@@ -20,7 +20,6 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         ("CLICKHOUSE_HOST", "clickhouse"),
         ("CLICKHOUSE_PORT", "9000"),
         ("CLICKHOUSE_HTTP_PORT", "8123"),
-        ("CLICKHOUSE_XAPI_DATABASE", "xapi"),
 
         # This can be used to override some configuration values in
         # via "docker_config.xml" file, which will be read from a
@@ -45,10 +44,6 @@ hooks.Filters.CONFIG_UNIQUE.add_items(
         # Prefix your setting names with 'CLICKHOUSE_'.
         ("CLICKHOUSE_ADMIN_USER", "ch_admin"),
         ("CLICKHOUSE_ADMIN_PASSWORD", "{{ 24|random_string }}"),
-        ("CLICKHOUSE_LRS_USER", "ch_lrs"),
-        ("CLICKHOUSE_LRS_PASSWORD", "{{ 24|random_string }}"),
-        ("CLICKHOUSE_REPORT_USER", "ch_report"),
-        ("CLICKHOUSE_REPORT_PASSWORD", "{{ 24|random_string }}"),
     ]
 )
 

--- a/tutorclickhouse/templates/clickhouse/tasks/init.sh
+++ b/tutorclickhouse/templates/clickhouse/tasks/init.sh
@@ -13,14 +13,3 @@ do
     sleep 10
 done
 echo "Clickhouse is up and running"
-
-# Create the xapi database if it doesn't exist
-clickhouse client --user {{ CLICKHOUSE_ADMIN_USER }} --password="{{ CLICKHOUSE_ADMIN_PASSWORD }}" --host "{{ CLICKHOUSE_HOST }}" --port {{ CLICKHOUSE_PORT }} -q "CREATE DATABASE IF NOT EXISTS {{ CLICKHOUSE_XAPI_DATABASE }};"
-
-# Create the LRS and reporting users
-clickhouse client --user {{ CLICKHOUSE_ADMIN_USER }} --password="{{ CLICKHOUSE_ADMIN_PASSWORD }}" --host "{{ CLICKHOUSE_HOST }}" --port {{ CLICKHOUSE_PORT }} -q "CREATE USER IF NOT EXISTS {{ CLICKHOUSE_LRS_USER}} IDENTIFIED WITH sha256_password BY '{{ CLICKHOUSE_LRS_PASSWORD }}';"
-clickhouse client --user {{ CLICKHOUSE_ADMIN_USER }} --password="{{ CLICKHOUSE_ADMIN_PASSWORD }}" --host "{{ CLICKHOUSE_HOST }}" --port {{ CLICKHOUSE_PORT }} -q "CREATE USER IF NOT EXISTS {{ CLICKHOUSE_REPORT_USER}} IDENTIFIED WITH sha256_password BY '{{ CLICKHOUSE_REPORT_PASSWORD }}';"
-
-# Grant basic permissions to the users
-clickhouse client --user {{ CLICKHOUSE_ADMIN_USER }} --password="{{ CLICKHOUSE_ADMIN_PASSWORD }}" --host "{{ CLICKHOUSE_HOST }}" --port {{ CLICKHOUSE_PORT }} -q "GRANT ALL ON {{ CLICKHOUSE_XAPI_DATABASE }}.* TO '{{ CLICKHOUSE_LRS_USER }}';"
-clickhouse client --user {{ CLICKHOUSE_ADMIN_USER }} --password="{{ CLICKHOUSE_ADMIN_PASSWORD }}" --host "{{ CLICKHOUSE_HOST }}" --port {{ CLICKHOUSE_PORT }} -q "GRANT SELECT ON {{ CLICKHOUSE_XAPI_DATABASE }}.* TO '{{ CLICKHOUSE_REPORT_USER }}';"


### PR DESCRIPTION
Some cleanup work here:

- Renaming "clickhouse_service" to just "clickhouse" to match other services
- Making the exposed ports match the base service as we do in other services
- Moving cross-service users / database creation to the OARS plugin (https://github.com/openedx/tutor-contrib-oars/pull/8)