### PR TITLE
refactor: use patch files instead programmatic declaration

### DIFF
--- a/tutorclickhouse/patches/local-docker-compose-jobs-services
+++ b/tutorclickhouse/patches/local-docker-compose-jobs-services
@@ -1,0 +1,4 @@
+clickhouse-job:
+    image: clickhouse/clickhouse-server:latest
+    depends_on: 
+        - clickhouse

--- a/tutorclickhouse/patches/local-docker-compose-services
+++ b/tutorclickhouse/patches/local-docker-compose-services
@@ -1,0 +1,23 @@
+clickhouse:
+    image: clickhouse/clickhouse-server:latest
+    environment:
+        CLICKHOUSE_DB: xapi
+        CLICKHOUSE_USER: "{{ CLICKHOUSE_ADMIN_USER }}"
+        CLICKHOUSE_PASSWORD: "{{ CLICKHOUSE_ADMIN_PASSWORD }}"
+        CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1
+    ports:
+        - 8123:{{ CLICKHOUSE_HTTP_PORT }}
+        - 9000:{{ CLICKHOUSE_PORT }}
+    healthcheck:
+        test: ["CMD-SHELL", "clickhouse client --user {{ CLICKHOUSE_ADMIN_USER}} --password {{CLICKHOUSE_ADMIN_PASSWORD }} --host {{ CLICKHOUSE_HOST }} --port {{ CLICKHOUSE_PORT }} -q 'exit' || exit 1"]
+        interval: 5s
+        timeout: 5s
+        retries: 3
+        start_period: 40s
+    ulimits:
+        nofile:
+            soft: 262144
+            hard: 262144
+    volumes:
+        - ../../data/clickhouse:/var/lib/clickhouse/
+        - ../../env/plugins/clickhouse/apps/config:/etc/clickhouse-server/config.d/

--- a/tutorclickhouse/plugin.py
+++ b/tutorclickhouse/plugin.py
@@ -115,49 +115,6 @@ hooks.Filters.ENV_TEMPLATE_TARGETS.add_items(
     ],
 )
 
-hooks.Filters.ENV_PATCHES.add_item(
-    (
-        "local-docker-compose-services",
-        """
-clickhouse:
-    image: clickhouse/clickhouse-server:latest
-    environment:
-        CLICKHOUSE_DB: xapi
-        CLICKHOUSE_USER: "{{ CLICKHOUSE_ADMIN_USER }}"
-        CLICKHOUSE_PASSWORD: "{{ CLICKHOUSE_ADMIN_PASSWORD }}"
-        CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1
-    ports:
-        - 8123:{{ CLICKHOUSE_HTTP_PORT }}
-        - 9000:{{ CLICKHOUSE_PORT }}
-    healthcheck:
-        test: ["CMD-SHELL", "clickhouse client --user {{ CLICKHOUSE_ADMIN_USER}} --password {{CLICKHOUSE_ADMIN_PASSWORD }} --host {{ CLICKHOUSE_HOST }} --port {{ CLICKHOUSE_PORT }} -q 'exit' || exit 1"]
-        interval: 5s
-        timeout: 5s
-        retries: 3
-        start_period: 40s
-    ulimits:
-        nofile:
-            soft: 262144
-            hard: 262144
-    volumes:
-        - ../../data/clickhouse:/var/lib/clickhouse/
-        - ../../env/plugins/clickhouse/apps/config:/etc/clickhouse-server/config.d/
-        """
-    )
-)
-
-hooks.Filters.ENV_PATCHES.add_item(
-    (
-        "local-docker-compose-jobs-services",
-        """
-clickhouse-job:
-    image: clickhouse/clickhouse-server:latest
-    depends_on: 
-        - clickhouse
-        """,
-    )
-)
-
 
 ########################################
 # PATCH LOADING


### PR DESCRIPTION
## Description
This PR moves the patches created programmatically in the plugin.py file into their patch files, which is the usual design followed by tutor plugins.

## How to test
You can follow the instructions [here](https://github.com/openedx/tutor-contrib-superset/pull/18).

## Authors concern
We found that the patch called `local-docker-compose-dev-jobs-services` doesn't exist according tutor's list of patches: https://docs.tutor.overhang.io/reference/patches.html. Should we use https://docs.tutor.overhang.io/reference/patches.html#dev-docker-compose-jobs-services instead?