### PR TITLE
fix: remove override command in k8s job

### DIFF
--- a/tutorclickhouse/patches/k8s-jobs
+++ b/tutorclickhouse/patches/k8s-jobs
@@ -12,7 +12,6 @@ spec:
       containers:
       - name: clickhouse
         image: {{ DOCKER_IMAGE_CLICKHOUSE }}
-        command: ["/bin/sh", "-c"]
         env:
           - name: CLICKHOUSE_DB
             value: "xapi"


### PR DESCRIPTION
## Description
This PR removes the command override from the clickhouse job which prevented its execution. This override it's not needed since tutor adds something similar when rendering the job:
![image](https://user-images.githubusercontent.com/64440265/234688699-2fa90cbc-0eeb-403c-8430-f18b9583dbb0.png)

So with the command override:
![empty-job](https://user-images.githubusercontent.com/64440265/234690884-b97cbac2-7c0f-4e48-87e6-f78a30b25b88.png)

Without the override:
![job-running](https://user-images.githubusercontent.com/64440265/234688787-aa1952dc-f1fb-4f5b-b62e-b5949e2ab5d3.png)

## How to test
Run:
`tutor k8s do init --limit clickhouse` then get the job output.